### PR TITLE
모바일 햄버거 버튼을 헤더에 통합

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,7 +1,7 @@
 <aside class="sidebar-width fixed left-0 top-0 h-screen border-r border-border bg-background overflow-y-auto -translate-x-full md:translate-x-0 transition-transform duration-300 z-40">
   <div class="flex flex-col h-full">
     <!-- Header -->
-    <div class="px-6 py-5 border-b border-border md:px-6 pl-16 md:pl-6">
+    <div class="px-6 py-5 border-b border-border">
       <a href="{{ '/' | relative_url }}" class="flex items-center gap-3 group no-underline">
         <svg class="h-5 w-5 text-primary transition-transform group-hover:scale-110 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,7 +28,13 @@
       <!-- Header -->
       <header class="sticky top-0 z-30 border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
         <div class="container flex items-center justify-between h-16 px-5 md:px-8">
-          <div class="flex items-center gap-4 md:ml-0 ml-16">
+          <div class="flex items-center gap-4">
+            <!-- Mobile Menu Button -->
+            <button class="md:hidden p-2 hover:bg-muted rounded-md transition-colors hover-warm" id="mobile-menu-btn" aria-label="메뉴 열기">
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+              </svg>
+            </button>
             {% if page.layout == "default" and page.title == "Home" %}
             <h2 class="text-base md:text-lg font-semibold">최근 게시글</h2>
             {% elsif page.title %}
@@ -62,13 +68,6 @@
       {% include footer.html %}
     </main>
   </div>
-
-  <!-- Mobile Menu Button -->
-  <button class="md:hidden fixed top-4 left-4 z-[60] p-2 bg-primary text-primary-foreground rounded-md" id="mobile-menu-btn" aria-label="Toggle menu">
-    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-    </svg>
-  </button>
 
   <!-- Scripts -->
   <script src="{{ '/assets/js/main.js' | relative_url }}"></script>


### PR DESCRIPTION
## 변경 사항
- 플로팅 버튼을 제거하고 메인 헤더 내부로 이동
- 사이드바 헤더의 불필요한 좌측 padding 제거
- 메인 헤더 컨텐츠의 좌측 margin 제거
- 햄버거 버튼이 다른 헤더 버튼들과 일관된 스타일로 통합

## 개선 효과
- 햄버거 버튼이 더 이상 플로팅되지 않고 자연스럽게 헤더에 통합됨
- 모바일에서 정렬이 정확해지고 레이아웃이 깔끔해짐