### PR TITLE
Development 카테고리 permalink를 소문자로 수정하여 404 해결

### DIFF
--- a/category/Development.html
+++ b/category/Development.html
@@ -2,5 +2,5 @@
 layout: category
 title: "Development"
 category: Development
-permalink: /category/Development/
+permalink: /category/development/
 ---


### PR DESCRIPTION
- permalink를 /category/development/로 변경
- category 속성은 Development 유지 (포스트와 일치)
- 소문자 URL 접근 시 404 오류 해결