### PR TITLE
모든 카테고리를 소문자로 통일하여 404 오류 완전 해결

### DIFF
--- a/_posts/2025-10/2025-10-07-dev-terms-summary.md
+++ b/_posts/2025-10/2025-10-07-dev-terms-summary.md
@@ -2,7 +2,7 @@
 layout: post
 title: "개발 용어 통합 정리"
 date: 2025-10-07 00:00:00 +0900
-categories: [Development, Terms]
+categories: [development, terms]
 tags: [개발용어, 프로그래밍, 기술정리, iterable, cors, restful-api, nosql]
 ---
 

--- a/_posts/2025-10/2025-10-07-eatprint-dev-log.md
+++ b/_posts/2025-10/2025-10-07-eatprint-dev-log.md
@@ -2,7 +2,7 @@
 layout: post
 title: "EatPrint 개발일지 - SNS 앱 개발 여정"
 date: 2025-10-07 04:00:00 +0900
-categories: [Project, Mobile]
+categories: [project, mobile]
 tags: [flutter, dart, python, flask, aws, dynamodb, postgresql, 앱개발]
 ---
 

--- a/_posts/2025-10/2025-10-07-git-github-guide.md
+++ b/_posts/2025-10/2025-10-07-git-github-guide.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Git/GitHub 사용 가이드"
 date: 2025-10-07 02:00:00 +0900
-categories: [Development, Git]
+categories: [development, git]
 tags: [git, github, 버전관리, 개발도구, 커밋]
 ---
 

--- a/_posts/2025-10/2025-10-07-mlops-phases.md
+++ b/_posts/2025-10/2025-10-07-mlops-phases.md
@@ -2,7 +2,7 @@
 layout: post
 title: "MLOps - 머신러닝 운영 프로세스"
 date: 2025-10-07 03:00:00 +0900
-categories: [Development, MLOps]
+categories: [development, mlops]
 tags: [mlops, 머신러닝, devops, ml-pipeline, 모델배포]
 ---
 

--- a/_posts/2025-10/2025-10-07-spamguardian-project.md
+++ b/_posts/2025-10/2025-10-07-spamguardian-project.md
@@ -2,7 +2,7 @@
 layout: post
 title: "SpamGuardian - 머신러닝 기반 스팸 필터링 프로젝트"
 date: 2025-10-07 01:00:00 +0900
-categories: [Project, Machine-Learning]
+categories: [project, machine-learning]
 tags: [머신러닝, 스팸필터, python, knn, naive-bayes, flask, react]
 ---
 

--- a/category/Development.html
+++ b/category/Development.html
@@ -1,6 +1,6 @@
 ---
 layout: category
 title: "Development"
-category: Development
+category: development
 permalink: /category/development/
 ---

--- a/category/Git.html
+++ b/category/Git.html
@@ -1,6 +1,6 @@
 ---
 layout: category
 title: "Git"
-category: Git
-permalink: /category/Git/
+category: git
+permalink: /category/git/
 ---

--- a/category/MLOps.html
+++ b/category/MLOps.html
@@ -1,6 +1,6 @@
 ---
 layout: category
 title: "MLOps"
-category: MLOps
-permalink: /category/MLOps/
+category: mlops
+permalink: /category/mlops/
 ---

--- a/category/Machine-Learning.html
+++ b/category/Machine-Learning.html
@@ -1,6 +1,6 @@
 ---
 layout: category
 title: "Machine Learning"
-category: Machine-Learning
-permalink: /category/Machine-Learning/
+category: machine-learning
+permalink: /category/machine-learning/
 ---

--- a/category/Mobile.html
+++ b/category/Mobile.html
@@ -1,6 +1,6 @@
 ---
 layout: category
 title: "Mobile"
-category: Mobile
-permalink: /category/Mobile/
+category: mobile
+permalink: /category/mobile/
 ---

--- a/category/Project.html
+++ b/category/Project.html
@@ -1,6 +1,6 @@
 ---
 layout: category
 title: "Project"
-category: Project
-permalink: /category/Project/
+category: project
+permalink: /category/project/
 ---

--- a/category/Terms.html
+++ b/category/Terms.html
@@ -1,6 +1,6 @@
 ---
 layout: category
 title: "Terms"
-category: Terms
-permalink: /category/Terms/
+category: terms
+permalink: /category/terms/
 ---


### PR DESCRIPTION
- 포스트의 모든 카테고리를 소문자로 변경
  - Development → development
  - Git → git
  - MLOps → mlops
  - Terms → terms
  - Project → project
  - Mobile → mobile
  - Machine-Learning → machine-learning

- 카테고리 페이지의 category 속성과 permalink를 소문자로 변경
- 사이드바에서 중복 카테고리 표시 문제 해결
- 모든 카테고리 링크에서 404 오류 해결