### PR TITLE
태그 페이지 자동 생성 시스템 구축 및 404 오류 해결

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -66,6 +66,7 @@ include:
   - _pages
   - _posts/**
   - category/**
+  - tags/**
 
 # Plugins
 plugins:

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -2,6 +2,16 @@
 layout: default
 ---
 
+{% comment %}
+jekyll-archives가 자동 생성할 때는 page.posts 사용
+수동 페이지일 때는 page.tag로 site.tags에서 가져옴
+{% endcomment %}
+{% if page.posts %}
+  {% assign tag_posts = page.posts %}
+{% else %}
+  {% assign tag_posts = site.tags[page.tag] %}
+{% endif %}
+
 <div class="tag-page max-w-4xl mx-auto">
   <header class="mb-6 md:mb-8">
     <div class="flex items-center gap-2 md:gap-3 mb-3 md:mb-4">
@@ -11,12 +21,12 @@ layout: default
       <h1 class="text-2xl md:text-4xl font-bold">{{ page.title }}</h1>
     </div>
     <p class="text-sm md:text-base text-muted-foreground">
-      총 {{ page.posts | size }}개의 글
+      총 {{ tag_posts | size }}개의 글
     </p>
   </header>
 
   <div class="grid gap-4 md:gap-6">
-    {% for post in page.posts %}
+    {% for post in tag_posts %}
     <article class="bg-card rounded-lg border border-border p-4 md:p-6 hover:shadow-lg transition-all hover:border-primary">
       <h2 class="text-lg md:text-2xl font-bold mb-1.5 md:mb-2">
         <a href="{{ post.url | relative_url }}" class="no-underline hover:text-primary text-foreground">

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "autoprefixer": "^10.4.16",
         "concurrently": "^8.2.2",
+        "js-yaml": "^4.1.0",
         "postcss": "^8.4.32",
         "tailwindcss": "^3.4.0"
       }
@@ -213,6 +214,13 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
@@ -908,6 +916,19 @@
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/lilconfig": {

--- a/package.json
+++ b/package.json
@@ -8,11 +8,13 @@
     "watch:css": "npx tailwindcss -i ./assets/css/main.css -o ./assets/css/output.css --watch",
     "build": "npm run build:css && bundle exec jekyll build",
     "validate:categories": "node scripts/validate-categories.js",
-    "prebuild": "npm run validate:categories"
+    "generate:tags": "node scripts/generate-tag-pages.js",
+    "prebuild": "npm run validate:categories && npm run generate:tags"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.16",
     "concurrently": "^8.2.2",
+    "js-yaml": "^4.1.0",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0"
   },

--- a/scripts/generate-tag-pages.js
+++ b/scripts/generate-tag-pages.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+// 태그 디렉토리 생성
+const tagsDir = path.join(__dirname, '..', 'tags');
+if (!fs.existsSync(tagsDir)) {
+  fs.mkdirSync(tagsDir, { recursive: true });
+}
+
+// 모든 포스트에서 태그 수집
+const postsDir = path.join(__dirname, '..', '_posts');
+const allTags = new Set();
+
+function collectTags(dir) {
+  const items = fs.readdirSync(dir);
+  
+  for (const item of items) {
+    const fullPath = path.join(dir, item);
+    const stat = fs.statSync(fullPath);
+    
+    if (stat.isDirectory()) {
+      collectTags(fullPath);
+    } else if (item.endsWith('.md')) {
+      const content = fs.readFileSync(fullPath, 'utf8');
+      const match = content.match(/^---\n([\s\S]*?)\n---/);
+      
+      if (match) {
+        try {
+          const frontmatter = yaml.load(match[1]);
+          if (frontmatter.tags && Array.isArray(frontmatter.tags)) {
+            frontmatter.tags.forEach(tag => allTags.add(tag));
+          }
+        } catch (e) {
+          console.error(`Error parsing ${fullPath}:`, e.message);
+        }
+      }
+    }
+  }
+}
+
+collectTags(postsDir);
+
+console.log(`Found ${allTags.size} unique tags`);
+
+// 각 태그에 대한 페이지 생성
+allTags.forEach(tag => {
+  const tagSlug = tag.toLowerCase().replace(/\s+/g, '-');
+  const tagFile = path.join(tagsDir, `${tagSlug}.html`);
+  
+  const content = `---
+layout: tag
+title: "${tag}"
+tag: ${tag}
+permalink: /tags/${tag}/
+---
+`;
+  
+  fs.writeFileSync(tagFile, content);
+  console.log(`Created: ${tagFile}`);
+});
+
+console.log('\nTag pages generated successfully!');

--- a/tags/activation-function.html
+++ b/tags/activation-function.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "activation-function"
+tag: activation-function
+permalink: /tags/activation-function/
+---

--- a/tags/ai.html
+++ b/tags/ai.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "ai"
+tag: ai
+permalink: /tags/ai/
+---

--- a/tags/algorithm.html
+++ b/tags/algorithm.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "algorithm"
+tag: algorithm
+permalink: /tags/algorithm/
+---

--- a/tags/algorithms.html
+++ b/tags/algorithms.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "algorithms"
+tag: algorithms
+permalink: /tags/algorithms/
+---

--- a/tags/array.html
+++ b/tags/array.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "array"
+tag: array
+permalink: /tags/array/
+---

--- a/tags/authentication.html
+++ b/tags/authentication.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "authentication"
+tag: authentication
+permalink: /tags/authentication/
+---

--- a/tags/availability.html
+++ b/tags/availability.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "availability"
+tag: availability
+permalink: /tags/availability/
+---

--- a/tags/batch-size.html
+++ b/tags/batch-size.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "batch-size"
+tag: batch-size
+permalink: /tags/batch-size/
+---

--- a/tags/bert.html
+++ b/tags/bert.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "bert"
+tag: bert
+permalink: /tags/bert/
+---

--- a/tags/branch.html
+++ b/tags/branch.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "branch"
+tag: branch
+permalink: /tags/branch/
+---

--- a/tags/broadcast.html
+++ b/tags/broadcast.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "broadcast"
+tag: broadcast
+permalink: /tags/broadcast/
+---

--- a/tags/cache.html
+++ b/tags/cache.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "cache"
+tag: cache
+permalink: /tags/cache/
+---

--- a/tags/calculus.html
+++ b/tags/calculus.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "calculus"
+tag: calculus
+permalink: /tags/calculus/
+---

--- a/tags/certification.html
+++ b/tags/certification.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "certification"
+tag: certification
+permalink: /tags/certification/
+---

--- a/tags/chatgpt.html
+++ b/tags/chatgpt.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "chatgpt"
+tag: chatgpt
+permalink: /tags/chatgpt/
+---

--- a/tags/circuit-switching.html
+++ b/tags/circuit-switching.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "circuit-switching"
+tag: circuit-switching
+permalink: /tags/circuit-switching/
+---

--- a/tags/classification.html
+++ b/tags/classification.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "classification"
+tag: classification
+permalink: /tags/classification/
+---

--- a/tags/coffee.html
+++ b/tags/coffee.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "coffee"
+tag: coffee
+permalink: /tags/coffee/
+---

--- a/tags/commit.html
+++ b/tags/commit.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "commit"
+tag: commit
+permalink: /tags/commit/
+---

--- a/tags/communication.html
+++ b/tags/communication.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "communication"
+tag: communication
+permalink: /tags/communication/
+---

--- a/tags/cookie.html
+++ b/tags/cookie.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "cookie"
+tag: cookie
+permalink: /tags/cookie/
+---

--- a/tags/cors.html
+++ b/tags/cors.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "cors"
+tag: cors
+permalink: /tags/cors/
+---

--- a/tags/cpp.html
+++ b/tags/cpp.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "cpp"
+tag: cpp
+permalink: /tags/cpp/
+---

--- a/tags/css.html
+++ b/tags/css.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "css"
+tag: css
+permalink: /tags/css/
+---

--- a/tags/data-analysis.html
+++ b/tags/data-analysis.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "data-analysis"
+tag: data-analysis
+permalink: /tags/data-analysis/
+---

--- a/tags/data-cleaning.html
+++ b/tags/data-cleaning.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "data-cleaning"
+tag: data-cleaning
+permalink: /tags/data-cleaning/
+---

--- a/tags/data-columns.html
+++ b/tags/data-columns.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "data-columns"
+tag: data-columns
+permalink: /tags/data-columns/
+---

--- a/tags/data-management.html
+++ b/tags/data-management.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "data-management"
+tag: data-management
+permalink: /tags/data-management/
+---

--- a/tags/data-preprocessing.html
+++ b/tags/data-preprocessing.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "data-preprocessing"
+tag: data-preprocessing
+permalink: /tags/data-preprocessing/
+---

--- a/tags/data-science.html
+++ b/tags/data-science.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "data-science"
+tag: data-science
+permalink: /tags/data-science/
+---

--- a/tags/data-types.html
+++ b/tags/data-types.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "data-types"
+tag: data-types
+permalink: /tags/data-types/
+---

--- a/tags/data.html
+++ b/tags/data.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "data"
+tag: data
+permalink: /tags/data/
+---

--- a/tags/database.html
+++ b/tags/database.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "database"
+tag: database
+permalink: /tags/database/
+---

--- a/tags/dataframe.html
+++ b/tags/dataframe.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "dataframe"
+tag: dataframe
+permalink: /tags/dataframe/
+---

--- a/tags/dbms.html
+++ b/tags/dbms.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "dbms"
+tag: dbms
+permalink: /tags/dbms/
+---

--- a/tags/debugging.html
+++ b/tags/debugging.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "debugging"
+tag: debugging
+permalink: /tags/debugging/
+---

--- a/tags/deep-learning.html
+++ b/tags/deep-learning.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "deep-learning"
+tag: deep-learning
+permalink: /tags/deep-learning/
+---

--- a/tags/dense-representation.html
+++ b/tags/dense-representation.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "dense-representation"
+tag: dense-representation
+permalink: /tags/dense-representation/
+---

--- a/tags/deployment.html
+++ b/tags/deployment.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "deployment"
+tag: deployment
+permalink: /tags/deployment/
+---

--- a/tags/destructor.html
+++ b/tags/destructor.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "destructor"
+tag: destructor
+permalink: /tags/destructor/
+---

--- a/tags/devops.html
+++ b/tags/devops.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "devops"
+tag: devops
+permalink: /tags/devops/
+---

--- a/tags/differentiation.html
+++ b/tags/differentiation.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "differentiation"
+tag: differentiation
+permalink: /tags/differentiation/
+---

--- a/tags/dikw.html
+++ b/tags/dikw.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "dikw"
+tag: dikw
+permalink: /tags/dikw/
+---

--- a/tags/dimension.html
+++ b/tags/dimension.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "dimension"
+tag: dimension
+permalink: /tags/dimension/
+---

--- a/tags/embedding.html
+++ b/tags/embedding.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "embedding"
+tag: embedding
+permalink: /tags/embedding/
+---

--- a/tags/encoding.html
+++ b/tags/encoding.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "encoding"
+tag: encoding
+permalink: /tags/encoding/
+---

--- a/tags/epoch.html
+++ b/tags/epoch.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "epoch"
+tag: epoch
+permalink: /tags/epoch/
+---

--- a/tags/error-handling.html
+++ b/tags/error-handling.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "error-handling"
+tag: error-handling
+permalink: /tags/error-handling/
+---

--- a/tags/evaluation.html
+++ b/tags/evaluation.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "evaluation"
+tag: evaluation
+permalink: /tags/evaluation/
+---

--- a/tags/facebook.html
+++ b/tags/facebook.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "facebook"
+tag: facebook
+permalink: /tags/facebook/
+---

--- a/tags/faiss.html
+++ b/tags/faiss.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "faiss"
+tag: faiss
+permalink: /tags/faiss/
+---

--- a/tags/gcp.html
+++ b/tags/gcp.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "gcp"
+tag: gcp
+permalink: /tags/gcp/
+---

--- a/tags/git.html
+++ b/tags/git.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "git"
+tag: git
+permalink: /tags/git/
+---

--- a/tags/github-pages.html
+++ b/tags/github-pages.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "github-pages"
+tag: github-pages
+permalink: /tags/github-pages/
+---

--- a/tags/github.html
+++ b/tags/github.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "github"
+tag: github
+permalink: /tags/github/
+---

--- a/tags/google-cloud-build.html
+++ b/tags/google-cloud-build.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "google-cloud-build"
+tag: google-cloud-build
+permalink: /tags/google-cloud-build/
+---

--- a/tags/graph.html
+++ b/tags/graph.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "graph"
+tag: graph
+permalink: /tags/graph/
+---

--- a/tags/gunicorn.html
+++ b/tags/gunicorn.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "gunicorn"
+tag: gunicorn
+permalink: /tags/gunicorn/
+---

--- a/tags/information-system.html
+++ b/tags/information-system.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "information-system"
+tag: information-system
+permalink: /tags/information-system/
+---

--- a/tags/ip-address.html
+++ b/tags/ip-address.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "ip-address"
+tag: ip-address
+permalink: /tags/ip-address/
+---

--- a/tags/iso.html
+++ b/tags/iso.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "iso"
+tag: iso
+permalink: /tags/iso/
+---

--- a/tags/iterable.html
+++ b/tags/iterable.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "iterable"
+tag: iterable
+permalink: /tags/iterable/
+---

--- a/tags/jekyll.html
+++ b/tags/jekyll.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "jekyll"
+tag: jekyll
+permalink: /tags/jekyll/
+---

--- a/tags/knowledge-management.html
+++ b/tags/knowledge-management.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "knowledge-management"
+tag: knowledge-management
+permalink: /tags/knowledge-management/
+---

--- a/tags/langchain.html
+++ b/tags/langchain.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "langchain"
+tag: langchain
+permalink: /tags/langchain/
+---

--- a/tags/linear-algebra.html
+++ b/tags/linear-algebra.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "linear-algebra"
+tag: linear-algebra
+permalink: /tags/linear-algebra/
+---

--- a/tags/llama.html
+++ b/tags/llama.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "llama"
+tag: llama
+permalink: /tags/llama/
+---

--- a/tags/llm.html
+++ b/tags/llm.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "llm"
+tag: llm
+permalink: /tags/llm/
+---

--- a/tags/loss-function.html
+++ b/tags/loss-function.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "loss-function"
+tag: loss-function
+permalink: /tags/loss-function/
+---

--- a/tags/machine-learning.html
+++ b/tags/machine-learning.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "machine-learning"
+tag: machine-learning
+permalink: /tags/machine-learning/
+---

--- a/tags/mae.html
+++ b/tags/mae.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "mae"
+tag: mae
+permalink: /tags/mae/
+---

--- a/tags/math.html
+++ b/tags/math.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "math"
+tag: math
+permalink: /tags/math/
+---

--- a/tags/mathematics.html
+++ b/tags/mathematics.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "mathematics"
+tag: mathematics
+permalink: /tags/mathematics/
+---

--- a/tags/matplotlib.html
+++ b/tags/matplotlib.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "matplotlib"
+tag: matplotlib
+permalink: /tags/matplotlib/
+---

--- a/tags/memory-leak.html
+++ b/tags/memory-leak.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "memory-leak"
+tag: memory-leak
+permalink: /tags/memory-leak/
+---

--- a/tags/memory-management.html
+++ b/tags/memory-management.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "memory-management"
+tag: memory-management
+permalink: /tags/memory-management/
+---

--- a/tags/message-switching.html
+++ b/tags/message-switching.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "message-switching"
+tag: message-switching
+permalink: /tags/message-switching/
+---

--- a/tags/missing-values.html
+++ b/tags/missing-values.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "missing-values"
+tag: missing-values
+permalink: /tags/missing-values/
+---

--- a/tags/ml-pipeline.html
+++ b/tags/ml-pipeline.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "ml-pipeline"
+tag: ml-pipeline
+permalink: /tags/ml-pipeline/
+---

--- a/tags/mlops.html
+++ b/tags/mlops.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "mlops"
+tag: mlops
+permalink: /tags/mlops/
+---

--- a/tags/mse.html
+++ b/tags/mse.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "mse"
+tag: mse
+permalink: /tags/mse/
+---

--- a/tags/natural-language-processing.html
+++ b/tags/natural-language-processing.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "natural-language-processing"
+tag: natural-language-processing
+permalink: /tags/natural-language-processing/
+---

--- a/tags/network-layers.html
+++ b/tags/network-layers.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "network-layers"
+tag: network-layers
+permalink: /tags/network-layers/
+---

--- a/tags/network.html
+++ b/tags/network.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "network"
+tag: network
+permalink: /tags/network/
+---

--- a/tags/neural-networks.html
+++ b/tags/neural-networks.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "neural-networks"
+tag: neural-networks
+permalink: /tags/neural-networks/
+---

--- a/tags/nllb.html
+++ b/tags/nllb.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "nllb"
+tag: nllb
+permalink: /tags/nllb/
+---

--- a/tags/nlp.html
+++ b/tags/nlp.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "nlp"
+tag: nlp
+permalink: /tags/nlp/
+---

--- a/tags/nosql.html
+++ b/tags/nosql.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "nosql"
+tag: nosql
+permalink: /tags/nosql/
+---

--- a/tags/numpy.html
+++ b/tags/numpy.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "numpy"
+tag: numpy
+permalink: /tags/numpy/
+---

--- a/tags/object-oriented-programming.html
+++ b/tags/object-oriented-programming.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "object-oriented-programming"
+tag: object-oriented-programming
+permalink: /tags/object-oriented-programming/
+---

--- a/tags/operating-system.html
+++ b/tags/operating-system.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "operating-system"
+tag: operating-system
+permalink: /tags/operating-system/
+---

--- a/tags/os.html
+++ b/tags/os.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "os"
+tag: os
+permalink: /tags/os/
+---

--- a/tags/osi-model.html
+++ b/tags/osi-model.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "osi-model"
+tag: osi-model
+permalink: /tags/osi-model/
+---

--- a/tags/packet-switching.html
+++ b/tags/packet-switching.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "packet-switching"
+tag: packet-switching
+permalink: /tags/packet-switching/
+---

--- a/tags/pandas.html
+++ b/tags/pandas.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "pandas"
+tag: pandas
+permalink: /tags/pandas/
+---

--- a/tags/pcb.html
+++ b/tags/pcb.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "pcb"
+tag: pcb
+permalink: /tags/pcb/
+---

--- a/tags/pointer.html
+++ b/tags/pointer.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "pointer"
+tag: pointer
+permalink: /tags/pointer/
+---

--- a/tags/port.html
+++ b/tags/port.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "port"
+tag: port
+permalink: /tags/port/
+---

--- a/tags/pre-training.html
+++ b/tags/pre-training.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "pre-training"
+tag: pre-training
+permalink: /tags/pre-training/
+---

--- a/tags/process.html
+++ b/tags/process.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "process"
+tag: process
+permalink: /tags/process/
+---

--- a/tags/prompt-engineering.html
+++ b/tags/prompt-engineering.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "prompt-engineering"
+tag: prompt-engineering
+permalink: /tags/prompt-engineering/
+---

--- a/tags/protocol.html
+++ b/tags/protocol.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "protocol"
+tag: protocol
+permalink: /tags/protocol/
+---

--- a/tags/python.html
+++ b/tags/python.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "python"
+tag: python
+permalink: /tags/python/
+---

--- a/tags/react.html
+++ b/tags/react.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "react"
+tag: react
+permalink: /tags/react/
+---

--- a/tags/regex.html
+++ b/tags/regex.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "regex"
+tag: regex
+permalink: /tags/regex/
+---

--- a/tags/regression.html
+++ b/tags/regression.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "regression"
+tag: regression
+permalink: /tags/regression/
+---

--- a/tags/reliability.html
+++ b/tags/reliability.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "reliability"
+tag: reliability
+permalink: /tags/reliability/
+---

--- a/tags/relu.html
+++ b/tags/relu.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "relu"
+tag: relu
+permalink: /tags/relu/
+---

--- a/tags/restful-api.html
+++ b/tags/restful-api.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "restful-api"
+tag: restful-api
+permalink: /tags/restful-api/
+---

--- a/tags/rounding.html
+++ b/tags/rounding.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "rounding"
+tag: rounding
+permalink: /tags/rounding/
+---

--- a/tags/router.html
+++ b/tags/router.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "router"
+tag: router
+permalink: /tags/router/
+---

--- a/tags/series.html
+++ b/tags/series.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "series"
+tag: series
+permalink: /tags/series/
+---

--- a/tags/server.html
+++ b/tags/server.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "server"
+tag: server
+permalink: /tags/server/
+---

--- a/tags/session.html
+++ b/tags/session.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "session"
+tag: session
+permalink: /tags/session/
+---

--- a/tags/socket.html
+++ b/tags/socket.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "socket"
+tag: socket
+permalink: /tags/socket/
+---

--- a/tags/structured-data.html
+++ b/tags/structured-data.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "structured-data"
+tag: structured-data
+permalink: /tags/structured-data/
+---

--- a/tags/subnet.html
+++ b/tags/subnet.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "subnet"
+tag: subnet
+permalink: /tags/subnet/
+---

--- a/tags/subnetting.html
+++ b/tags/subnetting.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "subnetting"
+tag: subnetting
+permalink: /tags/subnetting/
+---

--- a/tags/supervised-learning.html
+++ b/tags/supervised-learning.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "supervised-learning"
+tag: supervised-learning
+permalink: /tags/supervised-learning/
+---

--- a/tags/tableau.html
+++ b/tags/tableau.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "tableau"
+tag: tableau
+permalink: /tags/tableau/
+---

--- a/tags/tcp.html
+++ b/tags/tcp.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "tcp"
+tag: tcp
+permalink: /tags/tcp/
+---

--- a/tags/temperature.html
+++ b/tags/temperature.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "temperature"
+tag: temperature
+permalink: /tags/temperature/
+---

--- a/tags/text-classification.html
+++ b/tags/text-classification.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "text-classification"
+tag: text-classification
+permalink: /tags/text-classification/
+---

--- a/tags/text-formatting.html
+++ b/tags/text-formatting.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "text-formatting"
+tag: text-formatting
+permalink: /tags/text-formatting/
+---

--- a/tags/text-preprocessing.html
+++ b/tags/text-preprocessing.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "text-preprocessing"
+tag: text-preprocessing
+permalink: /tags/text-preprocessing/
+---

--- a/tags/text-processing.html
+++ b/tags/text-processing.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "text-processing"
+tag: text-processing
+permalink: /tags/text-processing/
+---

--- a/tags/throughput.html
+++ b/tags/throughput.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "throughput"
+tag: throughput
+permalink: /tags/throughput/
+---

--- a/tags/timeout.html
+++ b/tags/timeout.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "timeout"
+tag: timeout
+permalink: /tags/timeout/
+---

--- a/tags/token.html
+++ b/tags/token.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "token"
+tag: token
+permalink: /tags/token/
+---

--- a/tags/tokenization.html
+++ b/tags/tokenization.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "tokenization"
+tag: tokenization
+permalink: /tags/tokenization/
+---

--- a/tags/traceback.html
+++ b/tags/traceback.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "traceback"
+tag: traceback
+permalink: /tags/traceback/
+---

--- a/tags/training.html
+++ b/tags/training.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "training"
+tag: training
+permalink: /tags/training/
+---

--- a/tags/transfer-learning.html
+++ b/tags/transfer-learning.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "transfer-learning"
+tag: transfer-learning
+permalink: /tags/transfer-learning/
+---

--- a/tags/transformers.html
+++ b/tags/transformers.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "transformers"
+tag: transformers
+permalink: /tags/transformers/
+---

--- a/tags/translation.html
+++ b/tags/translation.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "translation"
+tag: translation
+permalink: /tags/translation/
+---

--- a/tags/troubleshooting.html
+++ b/tags/troubleshooting.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "troubleshooting"
+tag: troubleshooting
+permalink: /tags/troubleshooting/
+---

--- a/tags/udp.html
+++ b/tags/udp.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "udp"
+tag: udp
+permalink: /tags/udp/
+---

--- a/tags/unstructured-data.html
+++ b/tags/unstructured-data.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "unstructured-data"
+tag: unstructured-data
+permalink: /tags/unstructured-data/
+---

--- a/tags/vector-search.html
+++ b/tags/vector-search.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "vector-search"
+tag: vector-search
+permalink: /tags/vector-search/
+---

--- a/tags/vector.html
+++ b/tags/vector.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "vector"
+tag: vector
+permalink: /tags/vector/
+---

--- a/tags/version-control.html
+++ b/tags/version-control.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "version-control"
+tag: version-control
+permalink: /tags/version-control/
+---

--- a/tags/virtual.html
+++ b/tags/virtual.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "virtual"
+tag: virtual
+permalink: /tags/virtual/
+---

--- a/tags/visualization.html
+++ b/tags/visualization.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "visualization"
+tag: visualization
+permalink: /tags/visualization/
+---

--- a/tags/water-usage.html
+++ b/tags/water-usage.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "water-usage"
+tag: water-usage
+permalink: /tags/water-usage/
+---

--- a/tags/web-development.html
+++ b/tags/web-development.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "web-development"
+tag: web-development
+permalink: /tags/web-development/
+---

--- a/tags/web-security.html
+++ b/tags/web-security.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "web-security"
+tag: web-security
+permalink: /tags/web-security/
+---

--- a/tags/white-space.html
+++ b/tags/white-space.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "white-space"
+tag: white-space
+permalink: /tags/white-space/
+---

--- a/tags/개발도구.html
+++ b/tags/개발도구.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "개발도구"
+tag: 개발도구
+permalink: /tags/개발도구/
+---

--- a/tags/개발용어.html
+++ b/tags/개발용어.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "개발용어"
+tag: 개발용어
+permalink: /tags/개발용어/
+---

--- a/tags/기술정리.html
+++ b/tags/기술정리.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "기술정리"
+tag: 기술정리
+permalink: /tags/기술정리/
+---

--- a/tags/머신러닝.html
+++ b/tags/머신러닝.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "머신러닝"
+tag: 머신러닝
+permalink: /tags/머신러닝/
+---

--- a/tags/모델배포.html
+++ b/tags/모델배포.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "모델배포"
+tag: 모델배포
+permalink: /tags/모델배포/
+---

--- a/tags/버전관리.html
+++ b/tags/버전관리.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "버전관리"
+tag: 버전관리
+permalink: /tags/버전관리/
+---

--- a/tags/커밋.html
+++ b/tags/커밋.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "커밋"
+tag: 커밋
+permalink: /tags/커밋/
+---

--- a/tags/프로그래밍.html
+++ b/tags/프로그래밍.html
@@ -1,0 +1,6 @@
+---
+layout: tag
+title: "프로그래밍"
+tag: 프로그래밍
+permalink: /tags/프로그래밍/
+---


### PR DESCRIPTION
- 태그 페이지 자동 생성 스크립트 추가 (scripts/generate-tag-pages.js)
- 155개의 태그 페이지 생성 (tags/ 디렉토리)
- _layouts/tag.html 수정하여 수동 태그 페이지 지원
  - site.tags[page.tag] 사용하도록 변경
- package.json에 generate:tags 스크립트 추가
- prebuild 스크립트에서 태그 자동 생성 실행
- _config.yml에 tags/** 디렉토리 포함
- 태그 클릭 시 404 오류 완전 해결
